### PR TITLE
refactor: user 페이지 관련 코드수정

### DIFF
--- a/apps/fcdb/src/features/user-search/ui/UserSearchForm.server.tsx
+++ b/apps/fcdb/src/features/user-search/ui/UserSearchForm.server.tsx
@@ -1,36 +1,39 @@
 "use server";
 
-import { redirect } from "next/navigation";
 import { getOuidApi } from "@/entities/id/api";
 
 export async function userSearchAction(
-  prevState: { error: string | null },
+  prevState: { errorMessage: string | null },
   formData: FormData
-): Promise<{ error: string | null }> {
+): Promise<{ errorMessage: string | null; url: string | null }> {
   try {
     const name = formData.get("name") as string;
 
     if (!name || name.trim() === "") {
-      return { error: "구단주 이름을 입력해주세요." };
+      return { errorMessage: "구단주 이름을 입력해주세요.", url: null };
     }
 
     const result = await getOuidApi(name.trim());
 
     if (!result.ouid) {
-      return { error: "존재하지 않는 유저입니다." };
+      return { errorMessage: "존재하지 않는 유저입니다.", url: null };
     }
 
-    redirect(`/user/${name.trim()}`);
+    return { errorMessage: null, url: `/user/${name.trim()}` };
   } catch (error) {
     const errorMessage = error instanceof Error ? error.message : String(error);
 
     if (errorMessage.includes("OPENAPI00007")) {
       return {
-        error:
+        errorMessage:
           "서버가 일시적으로 사용할 수 없습니다. 잠시 후 다시 시도해주세요.",
+        url: null,
       };
     }
 
-    return { error: "검색 중 오류가 발생했습니다." };
+    return {
+      errorMessage: "검색 중 오류가 발생했습니다.",
+      url: null,
+    };
   }
 }

--- a/apps/fcdb/src/features/user-search/ui/UserSearchForm.tsx
+++ b/apps/fcdb/src/features/user-search/ui/UserSearchForm.tsx
@@ -4,15 +4,23 @@ import Form from "next/form";
 import { userSearchAction } from "./UserSearchForm.server";
 import { useActionState, useEffect } from "react";
 import { toast } from "sonner";
+import { useRouter } from "next/navigation";
 
 export const UserSearchForm = () => {
-  const [state, formAction] = useActionState(userSearchAction, { error: null });
+  const router = useRouter();
+  const [state, formAction] = useActionState(userSearchAction, {
+    url: null,
+    errorMessage: null,
+  });
 
   useEffect(() => {
-    if (state.error) {
-      toast.error(state.error);
+    if (state.errorMessage) {
+      toast.error(state.errorMessage);
     }
-  }, [state.error]);
+    if (state.url) {
+      router.push(state.url);
+    }
+  }, [state.errorMessage, state.url, router]);
 
   return (
     <Form action={formAction}>


### PR DESCRIPTION

form action 관련

- 정상적인 유저명을 입력시에도 존재하지않는 유저 혹은 반응이없는 부분 수정
- userSearchAction(server action)에서 유효한 유저명일경우 redirect되고있는데 이는 UserSearchForm.tsx내에 사용되고있는 useActionState에서 반환되는 값을 기대하고있지만 redirect가 되어버리면 내부적으로 에러로 보고 에러를 뱉고있음
- 라우팅될 url을 return 받아 router.push로 라우팅 시키는 쪽으로 수정
