### PR TITLE
존재하지 않는 유저 두번 이상 검색 시 toast error 안 보여주는 이슈 수정

### DIFF
--- a/apps/fcdb/src/features/user-search/ui/UserSearchForm.tsx
+++ b/apps/fcdb/src/features/user-search/ui/UserSearchForm.tsx
@@ -17,6 +17,10 @@ export const UserSearchForm = () => {
   });
 
   useEffect(() => {
+    if (isPending) {
+      return;
+    }
+
     if (state.errorMessage) {
       toast.error(state.errorMessage);
       setIsLoading(false);
@@ -24,7 +28,7 @@ export const UserSearchForm = () => {
     if (state.url) {
       router.push(state.url);
     }
-  }, [state.errorMessage, state.url, router]);
+  }, [state.errorMessage, state.url, router, isPending]);
 
   useEffect(() => {
     if (isPending) {


### PR DESCRIPTION
## Fix
- 존재하지 않는 유저 두번 이상 검색 시 toast error 안 보여주는 이슈

useEffect 의존성 배열에 포함된 state.errorMessage, state.url가 동일하여
useEffect가 실행되지 않아서 발생한 이슈입니다

`{errorMessage: '존재하지 않는 유저입니다.', url: null}`

검색할 때마다 변경되는 값인 isPending을 의존성 배열에 추가하여 해결했습니다



