### PR TITLE
플레이어 선수 이미지 PlayerImage 컴포넌트로 대체, 베스트 플레이어가 존재하지 않을 경우 빈 블럭 영역 잡히도록 수정

### DIFF
--- a/apps/fcdb/src/entities/player/ui/PlayerCard.tsx
+++ b/apps/fcdb/src/entities/player/ui/PlayerCard.tsx
@@ -4,9 +4,9 @@ import Badge from "@/entities/player/ui/Badge";
 import { POSITION } from "@/shared/constant/position";
 import { useQuery } from "@tanstack/react-query";
 import clsx from "clsx";
-import Image from "next/image";
 import { memo, useMemo } from "react";
 import { playerActionImageSource } from "../lib";
+import PlayerImage from "@/shared/components/PlayerImage";
 
 // TODO: 컴포넌트 분리, SRP에 맞게 분리
 // 포지션: spposition:number -> desc:string 교환`
@@ -45,7 +45,7 @@ const PlayerCard = ({ bestPlayer, isUser = true }: PlayerCardProps) => {
   }, [bestPlayer, soccerPlayerMeta]);
 
   if (!bestPlayer) {
-    return null;
+    return <div className="w-[124px] block" />;
   }
 
   const imageOverlayBaseStyle =
@@ -63,13 +63,12 @@ const PlayerCard = ({ bestPlayer, isUser = true }: PlayerCardProps) => {
         <div
           className={isUser ? userImageOverlayStyle : opponentImageOverlayStyle}
         >
-          <Image
-            src={playerImageSrc}
-            sizes="72px"
+          <PlayerImage
+            spId={bestPlayer.spId}
             alt={playerName || "선수 이미지"}
-            fill
+            width={72}
+            height={72}
             className="object-cover"
-            priority
           />
         </div>
         <div className="absolute w-full bottom-0 flex justify-center gap-[8px] z-1">

--- a/apps/fcdb/src/entities/profile/ui/PlayerProfileCard.tsx
+++ b/apps/fcdb/src/entities/profile/ui/PlayerProfileCard.tsx
@@ -1,7 +1,6 @@
 import { ReactElement } from "react";
 import styles from "./PlayerProfileCard.module.css";
-import Image from "next/image";
-import { playerActionImageSource } from "@/entities/player/lib";
+import PlayerImage from "@/shared/components/PlayerImage";
 
 interface PlayerProfileCardProps {
   spId: number;
@@ -14,13 +13,11 @@ interface PlayerProfileCardProps {
 export const PlayerProfileCard = ({
   spId,
 }: PlayerProfileCardProps): ReactElement => {
-  const imageSource = playerActionImageSource(spId);
   return (
     <div className={styles["profile-card"]}>
       {spId && (
-        <Image
-          className="absolute bottom-[6px]"
-          src={imageSource}
+        <PlayerImage
+          spId={spId}
           alt={`${spId}_action_image`}
           width={140}
           height={160}


### PR DESCRIPTION
### 변경 사항

- 프로필 카드 선수 이미지 `PlayerImage.tsx` 컴포넌트로 변경
- 베스트 플레이어 데이터가 없을 경우 빈 블럭 반환되도록 수정
  - 데이터가 존재하지 않을 경우 해당 영역이 잡히지 않아 스코어 레이아웃이 틀어지는 이슈

