### PR TITLE
hotfix: 매치 정보 변환 함수 nullable로 변경

### DIFF
--- a/apps/fcdb/src/entities/match/lib/getMatchInfo.ts
+++ b/apps/fcdb/src/entities/match/lib/getMatchInfo.ts
@@ -21,29 +21,25 @@ const covertMatchStatus = (
 /**@description 매치 정보 변환*/
 const convertMatchInfo = (
   matchInfo: MatchPlayerInfoType[]
-): ConvertedMatchInfo => {
+): ConvertedMatchInfo | null => {
   const firstMatch = matchInfo[0];
   const secondMatch = matchInfo[1];
 
-  if (!firstMatch || !secondMatch) {
-    throw new Error("매치 정보 없음");
-  }
-
   return {
     indicator: {
-      userNickName: firstMatch.nickname,
-      userPossession: firstMatch.matchDetail.possession ?? 0,
-      opponentNickName: secondMatch.nickname,
-      opponentPossession: secondMatch.matchDetail.possession ?? 0,
+      userNickName: firstMatch?.nickname ?? "",
+      userPossession: firstMatch?.matchDetail.possession ?? 0,
+      opponentNickName: secondMatch?.nickname ?? "",
+      opponentPossession: secondMatch?.matchDetail.possession ?? 0,
     },
     score: {
-      userScore: firstMatch.shoot.goalTotalDisplay,
-      opponentScore: secondMatch.shoot.goalTotalDisplay,
+      userScore: firstMatch?.shoot.goalTotalDisplay ?? 0,
+      opponentScore: secondMatch?.shoot.goalTotalDisplay ?? 0,
     },
-    matchResult: firstMatch.matchDetail.matchResult,
+    matchResult: firstMatch?.matchDetail.matchResult ?? "",
     players: {
-      user: firstMatch.player,
-      opponent: secondMatch.player,
+      user: firstMatch?.player ?? [],
+      opponent: secondMatch?.player ?? [],
     },
   };
 };


### PR DESCRIPTION
예상되는 원인은 경기 정보가 없을 경우 예외를 던지도록 되어있어서 발생한 문제 같습니다.

nullable을 허용하여 데이터가 없을 경우 기본값을 넘겨주도록 변경하였습니다.