### PR TITLE
UI, 사용성 개선

### DIFF
--- a/apps/fcdb/src/entities/formation/ui/Goal.tsx
+++ b/apps/fcdb/src/entities/formation/ui/Goal.tsx
@@ -24,7 +24,7 @@ export const Goal = ({ goal }: GoalProps) => {
         </div>
       </div>
       <div className="hidden mobile:block">
-        <div className="flex items-center justify-center top-[0px] -right-[28px] absolute">
+        <div className="flex items-center justify-center top-0 -right-[28px] absolute">
           <Image
             src={"/images/ball.png"}
             alt="ball-image"

--- a/apps/fcdb/src/entities/formation/ui/Goal.tsx
+++ b/apps/fcdb/src/entities/formation/ui/Goal.tsx
@@ -11,11 +11,11 @@ export const Goal = ({ goal }: GoalProps) => {
 
   return (
     <div>
-      <div className="hidden lg:block">
+      <div className="mobile:hidden">
         <div className="flex items-center justify-center -top-6 absolute">
           <Image
             src={"/images/ball.png"}
-            alt="season-image"
+            alt="ball-image"
             width={24}
             height={24}
             className="rounded-[4px]"
@@ -23,11 +23,11 @@ export const Goal = ({ goal }: GoalProps) => {
           <p className="mb-[2px] text-[#ABEE02]">{`x${goal}`}</p>
         </div>
       </div>
-      <div className="block lg:hidden">
-        <div className="flex items-center justify-center -top-[-20px] right-[-12px] absolute">
+      <div className="hidden mobile:block">
+        <div className="flex items-center justify-center top-[0px] -right-[28px] absolute">
           <Image
             src={"/images/ball.png"}
-            alt="season-image"
+            alt="ball-image"
             width={22}
             height={22}
             className="rounded-[4px]"

--- a/apps/fcdb/src/entities/formation/ui/Goal.tsx
+++ b/apps/fcdb/src/entities/formation/ui/Goal.tsx
@@ -12,7 +12,7 @@ export const Goal = ({ goal }: GoalProps) => {
   return (
     <div>
       <div className="mobile:hidden">
-        <div className="flex items-center justify-center -top-6 absolute">
+        <div className="flex items-center justify-center -top-[20px] absolute">
           <Image
             src={"/images/ball.png"}
             alt="ball-image"

--- a/apps/fcdb/src/entities/match/ui/PossessionIndicator.tsx
+++ b/apps/fcdb/src/entities/match/ui/PossessionIndicator.tsx
@@ -26,14 +26,16 @@ const PossessionIndicator = ({
   );
 
   return (
-    <figure className="flex w-full h-[36px] mobile:h-[30px] text-[20px] mobile:text-[10px] font-bold  mobile:pt-[10px]">
+    <figure className="flex w-full h-[36px] mobile:h-[44px] text-[20px] mobile:text-[10px] font-bold mobile:pt-[10px]">
       <section
         className={userSectionStyle}
         style={{
           width: formattedPosession.userPossession,
         }}
       >
-        <span className="truncate whitespace-nowrap">{userNickName}</span>
+        <span className="truncate whitespace-nowrap text-[16px]">
+          {userNickName}
+        </span>
         <span className="mobile:hidden">
           {formattedPosession.userPossession}
         </span>
@@ -49,7 +51,7 @@ const PossessionIndicator = ({
           {formattedPosession.opponentPossession}
         </span>
         <span
-          className="truncate whitespace-nowrap hover:cursor-pointer hover:scale-102 transition-transform"
+          className="truncate whitespace-nowrap hover:cursor-pointer hover:scale-102 transition-transform w-full text-right text-[16px]"
           onClick={() => onNicknameClick(opponentNickName)}
         >
           {opponentNickName}

--- a/apps/fcdb/src/entities/match/ui/PossessionIndicator.tsx
+++ b/apps/fcdb/src/entities/match/ui/PossessionIndicator.tsx
@@ -33,12 +33,7 @@ const PossessionIndicator = ({
           width: formattedPosession.userPossession,
         }}
       >
-        <span
-          className="truncate whitespace-nowrap hover:cursor-pointer hover:scale-102 transition-transform"
-          onClick={() => onNicknameClick(userNickName)}
-        >
-          {userNickName}
-        </span>
+        <span className="truncate whitespace-nowrap">{userNickName}</span>
         <span className="mobile:hidden">
           {formattedPosession.userPossession}
         </span>

--- a/apps/fcdb/src/entities/match/ui/PossessionIndicator.tsx
+++ b/apps/fcdb/src/entities/match/ui/PossessionIndicator.tsx
@@ -5,6 +5,7 @@ interface PossessionIndicatorProps {
   opponentPossession: number;
   userNickName: string;
   opponentNickName: string;
+  onNicknameClick: (nickname: string) => void;
 }
 
 const PossessionIndicator = ({
@@ -12,6 +13,7 @@ const PossessionIndicator = ({
   opponentPossession = 0,
   userNickName,
   opponentNickName,
+  onNicknameClick,
 }: PossessionIndicatorProps) => {
   const sectionBaseStyle =
     "flex items-center justify-between gap-[30px] px-[24px] mobile:px-[16px]";
@@ -31,7 +33,12 @@ const PossessionIndicator = ({
           width: formattedPosession.userPossession,
         }}
       >
-        <span className="truncate whitespace-nowrap">{userNickName}</span>
+        <span
+          className="truncate whitespace-nowrap hover:cursor-pointer hover:scale-102 transition-transform"
+          onClick={() => onNicknameClick(userNickName)}
+        >
+          {userNickName}
+        </span>
         <span className="mobile:hidden">
           {formattedPosession.userPossession}
         </span>
@@ -46,7 +53,12 @@ const PossessionIndicator = ({
         <span className="mobile:hidden">
           {formattedPosession.opponentPossession}
         </span>
-        <span className="truncate whitespace-nowrap">{opponentNickName}</span>
+        <span
+          className="truncate whitespace-nowrap hover:cursor-pointer hover:scale-102 transition-transform"
+          onClick={() => onNicknameClick(opponentNickName)}
+        >
+          {opponentNickName}
+        </span>
       </section>
     </figure>
   );

--- a/apps/fcdb/src/entities/match/ui/PossessionIndicator.tsx
+++ b/apps/fcdb/src/entities/match/ui/PossessionIndicator.tsx
@@ -26,14 +26,14 @@ const PossessionIndicator = ({
   );
 
   return (
-    <figure className="flex w-full h-[36px] mobile:h-[44px] text-[20px] mobile:text-[10px] font-bold mobile:pt-[10px]">
+    <figure className="flex w-full h-[36px] mobile:h-[36px] text-[20px] mobile:text-[10px] font-bold mobile:pt-[12px]">
       <section
         className={userSectionStyle}
         style={{
           width: formattedPosession.userPossession,
         }}
       >
-        <span className="truncate whitespace-nowrap text-[16px]">
+        <span className="truncate whitespace-nowrap mobile:text-[12px]">
           {userNickName}
         </span>
         <span className="mobile:hidden">
@@ -51,7 +51,7 @@ const PossessionIndicator = ({
           {formattedPosession.opponentPossession}
         </span>
         <span
-          className="truncate whitespace-nowrap hover:cursor-pointer hover:scale-102 transition-transform w-full text-right text-[16px]"
+          className="truncate whitespace-nowrap hover:cursor-pointer hover:scale-102 transition-transform w-full text-right mobile:text-[12px]"
           onClick={() => onNicknameClick(opponentNickName)}
         >
           {opponentNickName}

--- a/apps/fcdb/src/entities/player/ui/Badge.tsx
+++ b/apps/fcdb/src/entities/player/ui/Badge.tsx
@@ -9,7 +9,7 @@ const MvpBadge = ({ isMvp }: MvpBadgeProps) => {
   if (!isMvp) return null;
 
   return (
-    <div className="flex items-center justify-center absolute top-0 w-[42px] h-[25px] mobile:w-[30px] mobile:h-[18px] bg-[#ABEE02] text-[#000000] rounded-sm z-1">
+    <div className="flex items-center justify-center absolute top-0 -left-[28px] w-[42px] h-[25px] mobile:-left-[10px] mobile:w-[30px] mobile:h-[18px] bg-[#ABEE02] text-[#000000] rounded-sm z-1">
       <span className="font-medium mobile:font-[700] mobile:text-[10px]">
         MVP
       </span>

--- a/apps/fcdb/src/entities/player/ui/PlayerCard.tsx
+++ b/apps/fcdb/src/entities/player/ui/PlayerCard.tsx
@@ -57,7 +57,7 @@ const PlayerCard = ({ bestPlayer, isUser = true }: PlayerCardProps) => {
   const userImageOverlayStyle = clsx(imageOverlayBaseStyle, "border-[#ABEE02]");
 
   return (
-    <figure className="flex flex-col justify-between w-[124px] h-[117px] mobile:w-[80px] mobile:h-[88px]">
+    <figure className="flex flex-col justify-between w-[124px] h-[117px] mobile:w-[80px] mobile:h-[88px] items-center">
       <section className="relative h-[93px]">
         <Badge.Mvp isMvp={isUser} />
         <div
@@ -78,10 +78,12 @@ const PlayerCard = ({ bestPlayer, isUser = true }: PlayerCardProps) => {
       </section>
 
       <section className="flex gap-[4px] text-[14px] whitespace-nowrap mobile:pt-[6px]">
-        <span className="text-[#CE535D]">
+        <span className="text-[#CE535D] mobile:text-[10px]">
           {POSITION[spPosition as keyof typeof POSITION]}
         </span>
-        <span className="text-color-white">{playerName}</span>
+        <span className="text-color-white mobile:text-[10px]">
+          {playerName}
+        </span>
       </section>
     </figure>
   );

--- a/apps/fcdb/src/entities/profile/ui/ScoreRefresh.tsx
+++ b/apps/fcdb/src/entities/profile/ui/ScoreRefresh.tsx
@@ -27,13 +27,13 @@ const getTimeAgo = (updatedAt: Date): string => {
   const diffDays = Math.floor(diffHours / 24);
 
   if (diffSeconds < 60) {
-    return `업데이트 ${diffSeconds}초 전`;
+    return `${diffSeconds}초 전`;
   } else if (diffMinutes < 60) {
-    return `업데이트 ${diffMinutes}분 전`;
+    return `${diffMinutes}분 전`;
   } else if (diffHours < 24) {
-    return `업데이트 ${diffHours}시간 전`;
+    return `${diffHours}시간 전`;
   } else {
-    return `업데이트 ${diffDays}일 전`;
+    return `${diffDays}일 전`;
   }
 };
 
@@ -62,7 +62,9 @@ export const ScoreRefresh = ({
 
   return (
     <div className="flex flex-col items-center gap-[8px] text-sm text-gray-400">
-      <p className="text-[14px] w-full text-right">{timeAgo} 업데이트</p>
+      <p className="text-[14px] w-[120px] text-right truncate">
+        {timeAgo} 업데이트
+      </p>
       <ScoreRefreshButton onRefresh={handleClickOnRefresh} />
     </div>
   );

--- a/apps/fcdb/src/features/match/ui/MatchList.tsx
+++ b/apps/fcdb/src/features/match/ui/MatchList.tsx
@@ -42,7 +42,7 @@ export const MatchList = ({
         initialSummaries={initialData}
         isLoading={loading}
       />
-      <div className="w-full flex flex-col justify-center items-center gap-4">
+      <div className="w-full flex flex-col justify-center items-center gap-[8px] mobile:gap-[4px]">
         {infiniteSummaries?.map((match: MatchSummaryType, index: number) => (
           <div
             key={`${index}_match_list`}

--- a/apps/fcdb/src/features/match/ui/MatchSummary.tsx
+++ b/apps/fcdb/src/features/match/ui/MatchSummary.tsx
@@ -13,15 +13,21 @@ import { PlayerType } from "@/entities/match/types/match.types";
 import PossessionIndicator from "@/entities/match/ui/PossessionIndicator";
 import { UserSearchFormation } from "@/features/user-search/ui/UserSearchFormation";
 import { UserSearchFormationMoblie } from "@/features/user-search/ui/UserSearchFormationMoblie";
+import { useRouter } from "next/navigation";
 
 interface MatchSummaryProps {
   match: MatchSummaryType;
 }
 
 const MatchSummary = ({ match }: MatchSummaryProps): ReactElement => {
+  const router = useRouter();
   const [isExpanded, setIsExpanded] = useState(false);
 
   const winPlayer = match.matchInfo.matchResult === "승";
+
+  const handleNicknameClick = (nickname: string) => {
+    if (nickname) router.push(`/user/${nickname}`);
+  };
 
   return (
     <article className="flex w-full max-w-[1080px] rounded-[8px] bg-gray-900 border border-gray-800 overflow-hidden mobile:rounded-none">
@@ -83,6 +89,7 @@ const MatchSummary = ({ match }: MatchSummaryProps): ReactElement => {
           userPossession={match.matchInfo.indicator.userPossession ?? 0}
           opponentNickName={match.matchInfo.indicator.opponentNickName}
           opponentPossession={match.matchInfo.indicator.opponentPossession ?? 0}
+          onNicknameClick={handleNicknameClick}
         />
 
         <div

--- a/apps/fcdb/src/features/match/ui/MatchSummary.tsx
+++ b/apps/fcdb/src/features/match/ui/MatchSummary.tsx
@@ -68,7 +68,7 @@ const MatchSummary = ({ match }: MatchSummaryProps): ReactElement => {
           <button
             type="button"
             aria-expanded={isExpanded}
-            className="flex justify-center items-center w-[48px] h-[133px] mobile:w-[30px] mobile:h-[82px] border-l-2 border-gray-600 cursor-pointer"
+            className="flex justify-center items-center w-[48px] h-[133px] mobile:w-[40px] mobile:h-[82px] border-l-2 border-gray-600 cursor-pointer"
             onClick={() => setIsExpanded((prev) => !prev)}
           >
             <Image

--- a/apps/fcdb/src/features/user-search/ui/UserSearchFormationHalfCoatMoblie.tsx
+++ b/apps/fcdb/src/features/user-search/ui/UserSearchFormationHalfCoatMoblie.tsx
@@ -77,14 +77,16 @@ export const UserSearchFormationHalfCoatMoblie = ({
               }}
             >
               <div className="relative w-full h-full flex items-center justify-center">
-                <Goal goal={goal} />
-                <PlayerImage
-                  spId={soccerPlayer.spId}
-                  alt={playerName ? playerName : "선수 이미지"}
-                  width={38}
-                  height={38}
-                  className="rounded-full border-[1px] border-[#ABEE02]"
-                />
+                <div className="relative">
+                  <Goal goal={goal} />
+                  <PlayerImage
+                    spId={soccerPlayer.spId}
+                    alt={playerName ? playerName : "선수 이미지"}
+                    width={38}
+                    height={38}
+                    className="rounded-full border-[1px] border-[#ABEE02]"
+                  />
+                </div>
                 {seasonImg && (
                   <div className="absolute left-0 -bottom-[8px] w-full">
                     <div className="flex justify-center gap-[4px] w-full items-center">


### PR DESCRIPTION
## 주요 변경 사항
- 모바일 사용성 개선을 위해 accordion btn width 40으로 변경
   (모바일에서 아코디언 펼치는 버튼이 너무 작아서 누르기 힘들어서 변경)
- 모바일 PlayerCard, PossessionIndicator text 크기 조정
   (보기 좋은 크기로 변경)
- 모바일 매치리스트 유저, 상대 닉네임 font 크기 16px로 변경, 상대 닉네임 우측 정렬
- 매치리스트에서 상대 닉네임 클릭 시 상대의 매치리스트로 이동
  (사용성 개선을 위해 변경)
- 모바일 > 매치리스트에서 골 개수 보여주는 이미지 틀어짐 수정
- PC에서 업데이트 문구로 인해 전적, 승률 UI가 움직이는 이슈 수정
  (업데이트 문구가 1초마다 움직이면서 승률 UI가 움직여서 고정하도록 변경)
  
 단순 UI 수정 및 사용성 개선 작업입니다~