### PR TITLE
hotfix: 플레이어 베스트 액션샷 유저가 플레이한 선수로 표기되도록 수정

### DIFF
--- a/apps/fcdb/src/features/match/hooks/useInfiniteMatchSummaries.ts
+++ b/apps/fcdb/src/features/match/hooks/useInfiniteMatchSummaries.ts
@@ -40,13 +40,13 @@ export function useInfiniteMatchSummaries(
         });
 
         const info = convertMatchInfo(sortedMatchInfo);
-        const status = covertMatchStatus(match);
-        const players = convertPlayers(sortedMatchInfo);
+        const matchStatus = covertMatchStatus(match);
+        const matchPlayers = convertPlayers(sortedMatchInfo);
 
         return {
           matchInfo: info,
-          matchStatus: status,
-          matchPlayers: players,
+          matchStatus,
+          matchPlayers,
           matches: match,
         };
       })

--- a/apps/fcdb/src/features/profile/ui/UserProfileFetcher.tsx
+++ b/apps/fcdb/src/features/profile/ui/UserProfileFetcher.tsx
@@ -3,6 +3,7 @@
 import { ProfileSummary } from "./ProfileSummary";
 import {
   MatchSummaryType,
+  PlayerListType,
   ScorePanelType,
 } from "@/entities/match/types/match.info.types";
 import { useMemo } from "react";
@@ -32,7 +33,13 @@ export const UserProfileFetcher = ({
 }: UserProfileFetcherProps) => {
   const bestPlayer = useMemo(() => {
     return getBestPlayerActionShoot(
-      initialSummaries?.map((match) => match.matchPlayers).flat() || []
+      initialSummaries
+        ?.map((match) => {
+          if (match.matchPlayers.length === 0) return [];
+          return match.matchPlayers[0];
+        })
+        .filter((player): player is PlayerListType => player !== undefined)
+        .flat() || []
     );
   }, [initialSummaries]);
 


### PR DESCRIPTION
### 이슈

검색된 유저가 플레이한 선수가 아닌 상대방 선수가 베스트 플레이어로 노출되는 현상

이슈 원인 : 검색된 회원 선수뿐만 아니라 상대방 선수까지 포함하여 베스트 플레이어를 선정하도록 되어있었음

https://github.com/it-dev-front/front-mono/issues/79

### 변경 사항

1. 베스트 플레이어 선정 함수 내 검색된 유저 선수 목록만 조회되도록 수정

