### PR TITLE
PlayerImage 이미지 최적화 끄기 운영 서버에 적용

### DIFF
--- a/apps/fcdb/src/shared/components/PlayerImage.tsx
+++ b/apps/fcdb/src/shared/components/PlayerImage.tsx
@@ -17,6 +17,7 @@ export default function PlayerImage({ spId, ...rest }: any) {
 
   return (
     <Image
+      unoptimized
       {...rest}
       src={imgSrc}
       onError={() => {


### PR DESCRIPTION
vercel 이미지 최적화 사용량 제한으로 인해 최적화 끄기