### PR TITLE
매치 리스트 시즌 이미지 보여주기, 이미지 최적화 끄기

### DIFF
--- a/apps/docs/app/page.tsx
+++ b/apps/docs/app/page.tsx
@@ -12,8 +12,8 @@ const ThemeImage = (props: Props) => {
 
   return (
     <>
-      <Image {...rest} src={srcLight} className="imgLight" />
-      <Image {...rest} src={srcDark} className="imgDark" />
+      <Image unoptimized {...rest} src={srcLight} className="imgLight" />
+      <Image unoptimized {...rest} src={srcDark} className="imgDark" />
     </>
   );
 };
@@ -46,6 +46,7 @@ export default function Home() {
             rel="noopener noreferrer"
           >
             <Image
+              unoptimized
               className={styles.logo}
               src="/vercel.svg"
               alt="Vercel logomark"
@@ -74,6 +75,7 @@ export default function Home() {
           rel="noopener noreferrer"
         >
           <Image
+            unoptimized
             aria-hidden
             src="/window.svg"
             alt="Window icon"
@@ -88,6 +90,7 @@ export default function Home() {
           rel="noopener noreferrer"
         >
           <Image
+            unoptimized
             aria-hidden
             src="/globe.svg"
             alt="Globe icon"

--- a/apps/fcdb/src/app/(without-footer)/ranking/layout.tsx
+++ b/apps/fcdb/src/app/(without-footer)/ranking/layout.tsx
@@ -23,6 +23,7 @@ const RankingLayout = ({ children }: { children: React.ReactNode }) => {
     <main className="relative w-full min-w-[366px] flex flex-col min-h-screen pt-[62px]">
       <div className="w-[887px] h-[485px] fixed bottom-0 left-0 z-0 mobile:hidden">
         <Image
+          unoptimized
           src="/images/ranking-bg.png"
           fill
           alt="ranking-bg"

--- a/apps/fcdb/src/entities/formation/ui/Goal.tsx
+++ b/apps/fcdb/src/entities/formation/ui/Goal.tsx
@@ -14,6 +14,7 @@ export const Goal = ({ goal }: GoalProps) => {
       <div className="mobile:hidden">
         <div className="flex items-center justify-center -top-[20px] absolute">
           <Image
+            unoptimized
             src={"/images/ball.png"}
             alt="ball-image"
             width={24}
@@ -26,6 +27,7 @@ export const Goal = ({ goal }: GoalProps) => {
       <div className="hidden mobile:block">
         <div className="flex items-center justify-center top-0 -right-[28px] absolute">
           <Image
+            unoptimized
             src={"/images/ball.png"}
             alt="ball-image"
             width={22}

--- a/apps/fcdb/src/entities/player/ui/Badge.tsx
+++ b/apps/fcdb/src/entities/player/ui/Badge.tsx
@@ -25,7 +25,13 @@ interface SeasonBadgeProps {
 const SeasonBadge = ({ seasonImg }: SeasonBadgeProps) => {
   return (
     <div className="relative w-[39px] h-[25px] mobile:w-[30px] mobile:h-[18px] rounded-[4px] overflow-hidden">
-      <Image src={seasonImg} fill className="object-fill" alt="season-badge" />
+      <Image
+        unoptimized
+        src={seasonImg}
+        fill
+        className="object-fill"
+        alt="season-badge"
+      />
     </div>
   );
 };

--- a/apps/fcdb/src/entities/player/ui/Badge.tsx
+++ b/apps/fcdb/src/entities/player/ui/Badge.tsx
@@ -43,7 +43,7 @@ interface GradeBadgeProps {
 const GradeBadge = ({ spGrade }: GradeBadgeProps) => {
   //TODO: bg 스타일 tailwind에 정의
   const baseStyle =
-    "flex items-center justify-center w-[25px] h-[25px] rounded-[4px] mobile:w-[18px] mobile:h-[18px]";
+    "flex items-center justify-center w-[25px] h-[25px] rounded-[4px] mobile:w-[18px] mobile:h-[18px] text-[14px] mobile:text-[12px]";
   const textColor = spGrade < 5 ? "text-gray-100" : "text-gray-900";
   const backgroundColor =
     spGrade < 2

--- a/apps/fcdb/src/entities/player/ui/Badge.tsx
+++ b/apps/fcdb/src/entities/player/ui/Badge.tsx
@@ -18,20 +18,14 @@ const MvpBadge = ({ isMvp }: MvpBadgeProps) => {
 };
 
 interface SeasonBadgeProps {
-  seasonId?: number;
+  seasonImg: string;
 }
 
 // 4px 겹쳐짐
-const SeasonBadge = ({ seasonId }: SeasonBadgeProps) => {
-  // TODO: mapping하여 시즌이미지 가져오기
+const SeasonBadge = ({ seasonImg }: SeasonBadgeProps) => {
   return (
     <div className="relative w-[39px] h-[25px] mobile:w-[30px] mobile:h-[18px] rounded-[4px] overflow-hidden">
-      <Image
-        src="https://ssl.nexon.com/s2/game/fc/online/obt/externalAssets/new/season/lki.png"
-        fill
-        className="object-cover"
-        alt="season-badge"
-      />
+      <Image src={seasonImg} fill className="object-fill" alt="season-badge" />
     </div>
   );
 };

--- a/apps/fcdb/src/entities/player/ui/PlayerCard.tsx
+++ b/apps/fcdb/src/entities/player/ui/PlayerCard.tsx
@@ -26,6 +26,7 @@ interface PlayerCardProps {
 
 const PlayerCard = ({ bestPlayer, isUser = true }: PlayerCardProps) => {
   const { data: soccerPlayerMeta } = useQuery(MetaQueries.getPlayerMeta());
+  const { data: seasonIdMeta } = useQuery(MetaQueries.getSeasonIdMeta());
 
   const { spPosition, spGrade } = bestPlayer ?? {};
 
@@ -57,6 +58,10 @@ const PlayerCard = ({ bestPlayer, isUser = true }: PlayerCardProps) => {
   );
   const userImageOverlayStyle = clsx(imageOverlayBaseStyle, "border-[#ABEE02]");
 
+  const seasonImg = seasonIdMeta?.find(
+    (element) => element.seasonId == seasonId
+  )?.seasonImg;
+
   return (
     <figure className="flex flex-col justify-between w-[124px] h-[117px] mobile:w-[80px] mobile:h-[88px] items-center">
       <section className="relative h-[93px]">
@@ -73,7 +78,7 @@ const PlayerCard = ({ bestPlayer, isUser = true }: PlayerCardProps) => {
           />
         </div>
         <div className="absolute w-full bottom-0 flex justify-center gap-[8px] z-1">
-          {seasonId && <Badge.Season seasonId={seasonId} />}
+          {seasonImg && <Badge.Season seasonImg={seasonImg} />}
           <Badge.Grade spGrade={spGrade ?? 0} />
         </div>
       </section>

--- a/apps/fcdb/src/entities/tier/ui/TierImage.tsx
+++ b/apps/fcdb/src/entities/tier/ui/TierImage.tsx
@@ -18,6 +18,7 @@ export const TierImage = ({ divisionId }: TierImageProps): ReactElement => {
   const imageSource = findTierImage(divisionId);
   return (
     <Image
+      unoptimized
       className={"border-solid border-1 rounded-[50%]"}
       src={imageSource}
       alt={`${findDivisionLabel(divisionId)}_티어_이미지`}

--- a/apps/fcdb/src/features/match/ui/MatchSummary.tsx
+++ b/apps/fcdb/src/features/match/ui/MatchSummary.tsx
@@ -73,6 +73,7 @@ const MatchSummary = ({ match }: MatchSummaryProps): ReactElement => {
             onClick={() => setIsExpanded((prev) => !prev)}
           >
             <Image
+              unoptimized
               src="/arrow-green.svg"
               alt="접기/펼치기"
               width={16}

--- a/apps/fcdb/src/features/ranking/ui/RankingTableRow.tsx
+++ b/apps/fcdb/src/features/ranking/ui/RankingTableRow.tsx
@@ -51,6 +51,7 @@ export const RankingTableRow = ({ record }: RankingTableRowProps) => {
         <div className="relative overflow-hidden rounded-full w-15 h-15 mobile:w-10 mobile:h-10">
           {record.rankBestImg && (
             <Image
+              unoptimized
               src={record.rankBestImg}
               fill
               alt="최고등급"

--- a/apps/fcdb/src/features/user-search/ui/UserSearchFormationHalfCoatMoblie.tsx
+++ b/apps/fcdb/src/features/user-search/ui/UserSearchFormationHalfCoatMoblie.tsx
@@ -91,6 +91,7 @@ export const UserSearchFormationHalfCoatMoblie = ({
                   <div className="absolute left-0 -bottom-[8px] w-full">
                     <div className="flex justify-center gap-[4px] w-full items-center">
                       <Image
+                        unoptimized
                         src={seasonImg}
                         alt="season-image"
                         width={20}

--- a/apps/fcdb/src/features/user-search/ui/UserSearchPlayer.tsx
+++ b/apps/fcdb/src/features/user-search/ui/UserSearchPlayer.tsx
@@ -47,6 +47,7 @@ export const UserSearchPlayer = ({
         <div className="absolute left-0 -bottom-[20px] w-full">
           <div className="flex justify-between w-full items-center">
             <Image
+              unoptimized
               src={seasonImg}
               alt="season-image"
               width={26}

--- a/apps/fcdb/src/shared/ui/spinner/BallSpinner.tsx
+++ b/apps/fcdb/src/shared/ui/spinner/BallSpinner.tsx
@@ -4,6 +4,7 @@ export const BallSpinner = () => {
   return (
     <div>
       <Image
+        unoptimized
         src="/images/ball-spinner.gif"
         width={60}
         height={60}

--- a/apps/fcdb/src/widgets/Banner.tsx
+++ b/apps/fcdb/src/widgets/Banner.tsx
@@ -4,6 +4,7 @@ export const Banner = () => {
   return (
     <div className="relative w-[90vw] h-[46vw] lg:w-[640px] lg:h-[320px] rounded-xl overflow-hidden">
       <Image
+        unoptimized
         src="/images/banner.png"
         alt="logo"
         layout="fill"

--- a/apps/fcdb/src/widgets/Footer.tsx
+++ b/apps/fcdb/src/widgets/Footer.tsx
@@ -3,7 +3,14 @@ import Image from "next/image";
 export const Footer = () => {
   return (
     <footer className="w-full bg-gray-900 flex flex-col items-center justify-center py-16">
-      <Image src="/logo.svg" alt="logo" width={108} height={20} priority />
+      <Image
+        unoptimized
+        src="/logo.svg"
+        alt="logo"
+        width={108}
+        height={20}
+        priority
+      />
       <p className="text-[#FFFFFF] text-lg pt-[18px] lg:text-xl">
         Data based on NEXON DEVELOPERS
       </p>

--- a/apps/fcdb/src/widgets/navigation/index.tsx
+++ b/apps/fcdb/src/widgets/navigation/index.tsx
@@ -25,7 +25,14 @@ export const Navigation = () => {
           href="/"
           className="w-[108px] h-[20px] min-w-[108px] min-h-[20px] shrink-0 flex items-center"
         >
-          <Image src="/logo.svg" alt="logo" width={108} height={20} priority />
+          <Image
+            unoptimized
+            src="/logo.svg"
+            alt="logo"
+            width={108}
+            height={20}
+            priority
+          />
         </Link>
 
         <nav


### PR DESCRIPTION
## Changes
- 매치 리스트에 선수 시즌 이미지 불러오도록 수정, 시즌 이미지 짤림 수정
- vercel 무료 플랜 이미지 최적화 사용량 제한으로 인해 이미지 최적화 끄기
- GradeBadge text 크기 조정

